### PR TITLE
make each config entry have their own informers, other test fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,9 @@ type Config struct {
 type Entry struct {
 	Interval      time.Duration   `yaml:"interval"`
 	Namespace     string          `yaml:"namespace"`
-	LabelSelector labels.Selector `yaml:"matchExpressions"`
+	LabelSelector labels.Selector `yaml:"labelSelector"`
 	NodeLabel     string          `yaml:"nodeLabel"`
+	ResyncPeriod  time.Duration   `yaml:"resyncPeriod"`
 }
 
 func Read(io.Reader) (*Config, error) {

--- a/nodelabeler_test.go
+++ b/nodelabeler_test.go
@@ -108,11 +108,9 @@ func testMigratingPodSequence(t *testing.T, fakeCS bool) {
 				Namespace:     testns,
 				LabelSelector: selector(t, "app.k8s.io/name=pod1"),
 				NodeLabel:     testLabel,
+				ResyncPeriod:  resyncPeriod,
 			},
 		},
-		// Informers interact weirdly with the k8s fake client. Work around that by making them poll very often.
-		// Ref: https://github.com/kubernetes/kubernetes/issues/95372#issuecomment-717016660
-		ResyncPeriod: resyncPeriod,
 	}
 
 	// WG to wait for the nodeLabeler goroutine before ending the test. Wait() must be deferred before cancelling the context.


### PR DESCRIPTION
This way, informers can be namespaced, which should be lighter on the
apiserver.

As a tradeoff, one node informer will be created for each entry. This
can be prevented by having one shared, non-namespaced factory for nodes
and per-entry factories for pods, but I chose to not optimize
prematurely for now